### PR TITLE
Fix Repo URL typos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,103 +3,103 @@
 	url = https://github.com/CCob/SQL-BOF
 [submodule "BOFs/CS-Situational-Awareness-BOF"]
 	path = BOFs/CS-Situational-Awareness-BOF
-	url = https:/github.com/trustedsec/CS-Situational-Awareness-BOF
+	url = https://github.com/trustedsec/CS-Situational-Awareness-BOF
 [submodule "BOFs/BOF_Collection"]
 	path = BOFs/BOF_Collection
-	url = https:/github.com/rvrsh3ll/BOF_Collection
+	url = https://github.com/rvrsh3ll/BOF_Collection
 [submodule "BOFs/whereami"]
 	path = BOFs/whereami
-	url = https:/github.com/boku7/whereami
+	url = https://github.com/boku7/whereami
 [submodule "BOFs/BOFs"]
 	path = BOFs/BOFs
-	url = https:/github.com/RiccardoAncarani/BOFs
+	url = https://github.com/RiccardoAncarani/BOFs
 [submodule "BOFs/C2-Tool-Collection"]
 	path = BOFs/C2-Tool-Collection
-	url = https:/github.com/outflanknl/C2-Tool-Collection
+	url = https://github.com/outflanknl/C2-Tool-Collection
 [submodule "BOFs/cobaltstrike-cat-bof"]
 	path = BOFs/cobaltstrike-cat-bof
-	url = https:/github.com/tvgdb/cobaltstrike-cat-bof
+	url = https://github.com/tvgdb/cobaltstrike-cat-bof
 [submodule "BOFs/tgtdelegation"]
 	path = BOFs/tgtdelegation
-	url = https:/github.com/sliverarmory/tgtdelegation
+	url = https://github.com/sliverarmory/tgtdelegation
 [submodule "BOFs/PrivKit"]
 	path = BOFs/PrivKit
-	url = https:/github.com/mertdas/PrivKit
+	url = https://github.com/mertdas/PrivKit
 [submodule "BOFs/BOF-enumfiles"]
 	path = BOFs/BOF-enumfiles
-	url = https:/github.com/wsummerhill/BOF-enumfiles
+	url = https://github.com/wsummerhill/BOF-enumfiles
 [submodule "BOFs/xPipe"]
 	path = BOFs/xPipe
-	url = https:/github.com/boku7/xPipe
+	url = https://github.com/boku7/xPipe
 [submodule "BOFs/InlineExecute-Assembly"]
 	path = BOFs/InlineExecute-Assembly
-	url = https:/github.com/anthemtotheego/InlineExecute-Assembly
+	url = https://github.com/anthemtotheego/InlineExecute-Assembly
 [submodule "BOFs/inject-assembly"]
 	path = BOFs/inject-assembly
-	url = https:/github.com/kyleavery/inject-assembly
+	url = https://github.com/kyleavery/inject-assembly
 [submodule "BOFs/BOF.NET"]
 	path = BOFs/BOF.NET
-	url = https:/github.com/CCob/BOF.NET
+	url = https://github.com/CCob/BOF.NET
 [submodule "BOFs/ThreadlessInject-BOF"]
 	path = BOFs/ThreadlessInject-BOF
-	url = https:/github.com/iilegacyyii/ThreadlessInject-BOF
+	url = https://github.com/iilegacyyii/ThreadlessInject-BOF
 [submodule "BOFs/BOF-RegSave"]
 	path = BOFs/BOF-RegSave
-	url = https:/github.com/EncodeGroup/BOF-RegSave
+	url = https://github.com/EncodeGroup/BOF-RegSave
 [submodule "BOFs/unhook-bof"]
 	path = BOFs/unhook-bof
-	url = https:/github.com/rsmudge/unhook-bof
+	url = https://github.com/rsmudge/unhook-bof
 [submodule "BOFs/WdToggle"]
 	path = BOFs/WdToggle
-	url = https:/github.com/outflanknl/WdToggle
+	url = https://github.com/outflanknl/WdToggle
 [submodule "BOFs/CS-Remote-OPs-BOF"]
 	path = BOFs/CS-Remote-OPs-BOF
-	url = https:/github.com/trustedsec/CS-Remote-OPs-BOF
+	url = https://github.com/trustedsec/CS-Remote-OPs-BOF
 [submodule "BOFs/injectAmsiBypass"]
 	path = BOFs/injectAmsiBypass
-	url = https:/github.com/boku7/injectAmsiBypass
+	url = https://github.com/boku7/injectAmsiBypass
 [submodule "BOFs/injectEtwBypass"]
 	path = BOFs/injectEtwBypass
-	url = https:/github.com/boku7/injectEtwBypass
+	url = https://github.com/boku7/injectEtwBypass
 [submodule "BOFs/BOF-patchit"]
 	path = BOFs/BOF-patchit
-	url = https:/github.com/ScriptIdiot/BOF-patchit
+	url = https://github.com/ScriptIdiot/BOF-patchit
 [submodule "BOFs/BofRoast"]
 	path = BOFs/BofRoast
-	url = https:/github.com/cube0x0/BofRoast
+	url = https://github.com/cube0x0/BofRoast
 [submodule "BOFs/Koh"]
 	path = BOFs/Koh
-	url = https:/github.com/GhostPack/Koh
+	url = https://github.com/GhostPack/Koh
 [submodule "BOFs/Kerbeus-BOF"]
 	path = BOFs/Kerbeus-BOF
-	url = https:/github.com/RalfHacker/Kerbeus-BOF
+	url = https://github.com/RalfHacker/Kerbeus-BOF
 [submodule "BOFs/ScreenshotBOF"]
 	path = BOFs/ScreenshotBOF
-	url = https:/github.com/CodeXTF2/ScreenshotBOF
+	url = https://github.com/CodeXTF2/ScreenshotBOF
 [submodule "BOFs/nanorobeus"]
 	path = BOFs/nanorobeus
-	url = https:/github.com/wavvs/nanorobeus
+	url = https://github.com/wavvs/nanorobeus
 [submodule "BOFs/Defender-Exclusions-Creator-BOF"]
 	path = BOFs/Defender-Exclusions-Creator-BOF
-	url = https:/github.com/EspressoCake/Defender-Exclusions-Creator-BOF
+	url = https://github.com/EspressoCake/Defender-Exclusions-Creator-BOF
 [submodule "BOFs/SQL-BOF"]
 	path = BOFs/SQL-BOF
-	url = https:/github.com/Tw1sm/SQL-BOF
+	url = https://github.com/Tw1sm/SQL-BOF
 [submodule "BOFs/ChromeKatz"]
 	path = BOFs/ChromeKatz
-	url = https:/github.com/Meckazin/ChromeKatz
+	url = https://github.com/Meckazin/ChromeKatz
 [submodule "BOFs/bof_template"]
 	path = BOFs/bof_template
-	url = https:/github.com/Cobalt-Strike/bof_template
+	url = https://github.com/Cobalt-Strike/bof_template
 [submodule "BOFs/bofhound"]
 	path = BOFs/bofhound
-	url = https:/github.com/fortalice/bofhound
+	url = https://github.com/fortalice/bofhound
 [submodule "BOFs/HiddenDesktop"]
 	path = BOFs/HiddenDesktop
-	url = https:/github.com/WKL-Sec/HiddenDesktop
+	url = https://github.com/WKL-Sec/HiddenDesktop
 [submodule "Aggressors/submodules/HelpColor"]
 	path = Aggressors/submodules/HelpColor
-	url = https:/github.com/outflanknl/HelpColor
+	url = https://github.com/outflanknl/HelpColor
 [submodule "BOFs/EDRenum-BOF"]
 	path = BOFs/EDRenum-BOF
-	url = https:/github.com/mlcsec/EDRenum-BOF
+	url = https://github.com/mlcsec/EDRenum-BOF


### PR DESCRIPTION
Some submodule URLs use https:/github.com instead of https://github.com, causing the submodule cloning to fail.